### PR TITLE
feat: add directory selection to line-counter script

### DIFF
--- a/git-practice/line-counter/line_counter.py
+++ b/git-practice/line-counter/line_counter.py
@@ -1,9 +1,13 @@
-# line_counter.py
-
 import os
+import sys
 
-for filename in os.listdir():
-    if filename.endswith(".txt"):
-        with open(filename) as f:
-            lines = f.readlines()
-            print(f"{filename}: {len(lines)} lines")
+def count_lines(filepath):
+    with open(filepath) as f:
+        return len(f.readlines())
+
+if __name__ == "__main__":
+    target_dir = sys.argv[1] if len(sys.argv) > 1 else "."
+    for filename in os.listdir(target_dir):
+        if filename.endswith(".txt"):
+            full_path = os.path.join(target_dir, filename)
+            print(f"{filename}: {count_lines(full_path)} lines")


### PR DESCRIPTION
## Summary

This PR adds basic command-line argument support to the `line_counter.py` script.

- Users can now specify a directory to scan for `.txt` files.
- If no argument is passed, the current directory (`.`) is used by default.

## Example usage

```bash
python line_counter.py data/
